### PR TITLE
Fixed issue by cloning serialized potion data when cloning recipe.

### DIFF
--- a/Scripts/Services/RecipeReconstructionService.cs
+++ b/Scripts/Services/RecipeReconstructionService.cs
@@ -209,7 +209,8 @@ namespace PotionCraftUsefulRecipeMarks.Scripts.Services
             //DebugLogObject(reconstructionTimeline);
 
             var newRecipe = (Potion)recipeToClone.Clone();
-            var newRecipeRecipeData = newRecipe.GetRecipeData();
+            var newRecipeRecipeData = (SerializedPotionRecipeData)newRecipe.GetRecipeData().Clone();
+            Traverse.Create(newRecipe).Field("recipeData").SetValue(newRecipeRecipeData);
 
             //Setup used components
             //Sort indexes from high to low for efficient searching


### PR DESCRIPTION
For some reason the seralized potion data was doing a shallow copy on clone instead of a full clone leading to changes to the original recipe when modifying the cloned serialized data for reconstructed recipe.